### PR TITLE
Add mobile keyboard shortcuts and improved UI for terminal control

### DIFF
--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -843,10 +843,13 @@ export class SessionView extends LitElement {
         break;
       case 'cmd+k':
         // On macOS, Cmd+K is often used to clear the terminal
-        await this.sendInputText('\x0b');
+        await this.sendInputText('\x0c'); // Ctrl+L - clear terminal
         break;
       case 'cmd+z':
-        await this.sendInputText('\x1a');
+        // For undo functionality, we need to send the actual Cmd+Z
+        // Most terminal apps don't support undo, so we'll remove this
+        // or could send Ctrl+_ (\x1f) which is undo in some terminals
+        await this.sendInputText('\x1f'); // Ctrl+_ - undo in nano/emacs
         break;
     }
   }
@@ -1406,14 +1409,16 @@ export class SessionView extends LitElement {
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
                       @click=${() => this.handleShortcut('cmd+k')}
+                      title="Clear terminal"
                     >
-                      Cmd+K
+                      Clear
                     </button>
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
                       @click=${() => this.handleShortcut('cmd+z')}
+                      title="Undo (Ctrl+_) - works in nano/emacs"
                     >
-                      Undo
+                      Ctrl+_
                     </button>
                   </div>
                 </div>

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -806,43 +806,16 @@ export class SessionView extends LitElement {
         await this.sendInputText('\x1b[Z'); // Shift+Tab escape sequence
         break;
       case 'ctrl+c':
-        await this.sendInputText('\x03');
+        await this.sendInputText('\x03'); // Interrupt/Cancel
         break;
       case 'ctrl+z':
-        await this.sendInputText('\x1a');
-        break;
-      case 'ctrl+a':
-        await this.sendInputText('\x01');
-        break;
-      case 'ctrl+e':
-        await this.sendInputText('\x05');
-        break;
-      case 'ctrl+k':
-        await this.sendInputText('\x0b');
-        break;
-      case 'ctrl+l':
-        await this.sendInputText('\x0c');
-        break;
-      case 'ctrl+r':
-        await this.sendInputText('\x12');
+        await this.sendInputText('\x1a'); // Suspend process
         break;
       case 'ctrl+d':
-        await this.sendInputText('\x04');
+        await this.sendInputText('\x04'); // End of file/Exit
         break;
-      case 'ctrl+w':
-        await this.sendInputText('\x17');
-        break;
-      case 'ctrl+u':
-        await this.sendInputText('\x15');
-        break;
-      case 'alt+b':
-        await this.sendInputText('\x1bb'); // ESC + b
-        break;
-      case 'alt+f':
-        await this.sendInputText('\x1bf'); // ESC + f
-        break;
-      case 'ctrl+underscore':
-        await this.sendInputText('\x1f'); // Ctrl+_ - undo in nano/emacs
+      case 'ctrl+l':
+        await this.sendInputText('\x0c'); // Clear terminal
         break;
     }
   }
@@ -1330,81 +1303,30 @@ export class SessionView extends LitElement {
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
                       @click=${() => this.handleShortcut('ctrl+c')}
+                      title="Interrupt/Cancel"
                     >
                       Ctrl+C
                     </button>
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
                       @click=${() => this.handleShortcut('ctrl+z')}
+                      title="Suspend process"
                     >
                       Ctrl+Z
                     </button>
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+a')}
+                      @click=${() => this.handleShortcut('ctrl+d')}
+                      title="End of file/Exit"
                     >
-                      Ctrl+A
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+e')}
-                    >
-                      Ctrl+E
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+k')}
-                    >
-                      Ctrl+K
+                      Ctrl+D
                     </button>
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
                       @click=${() => this.handleShortcut('ctrl+l')}
+                      title="Clear terminal"
                     >
                       Clear
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+r')}
-                    >
-                      Search
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+d')}
-                    >
-                      EOF
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+w')}
-                    >
-                      Del Word
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+u')}
-                    >
-                      Del Line
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('alt+b')}
-                    >
-                      Word ←
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('alt+f')}
-                    >
-                      Word →
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('ctrl+underscore')}
-                      title="Undo (Ctrl+_) - works in nano/emacs"
-                    >
-                      Ctrl+_
                     </button>
                   </div>
                 </div>

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -841,14 +841,7 @@ export class SessionView extends LitElement {
       case 'alt+f':
         await this.sendInputText('\x1bf'); // ESC + f
         break;
-      case 'cmd+k':
-        // On macOS, Cmd+K is often used to clear the terminal
-        await this.sendInputText('\x0c'); // Ctrl+L - clear terminal
-        break;
-      case 'cmd+z':
-        // For undo functionality, we need to send the actual Cmd+Z
-        // Most terminal apps don't support undo, so we'll remove this
-        // or could send Ctrl+_ (\x1f) which is undo in some terminals
+      case 'ctrl+underscore':
         await this.sendInputText('\x1f'); // Ctrl+_ - undo in nano/emacs
         break;
     }
@@ -1408,14 +1401,7 @@ export class SessionView extends LitElement {
                     </button>
                     <button
                       class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('cmd+k')}
-                      title="Clear terminal"
-                    >
-                      Clear
-                    </button>
-                    <button
-                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
-                      @click=${() => this.handleShortcut('cmd+z')}
+                      @click=${() => this.handleShortcut('ctrl+underscore')}
                       title="Undo (Ctrl+_) - works in nano/emacs"
                     >
                       Ctrl+_

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -799,6 +799,58 @@ export class SessionView extends LitElement {
     await this.sendInputText(key);
   }
 
+  private async handleShortcut(shortcut: string) {
+    switch (shortcut) {
+      case 'shift+tab':
+        // Send the key sequence that enables Claude Code file writes
+        await this.sendInputText('\x1b[Z'); // Shift+Tab escape sequence
+        break;
+      case 'ctrl+c':
+        await this.sendInputText('\x03');
+        break;
+      case 'ctrl+z':
+        await this.sendInputText('\x1a');
+        break;
+      case 'ctrl+a':
+        await this.sendInputText('\x01');
+        break;
+      case 'ctrl+e':
+        await this.sendInputText('\x05');
+        break;
+      case 'ctrl+k':
+        await this.sendInputText('\x0b');
+        break;
+      case 'ctrl+l':
+        await this.sendInputText('\x0c');
+        break;
+      case 'ctrl+r':
+        await this.sendInputText('\x12');
+        break;
+      case 'ctrl+d':
+        await this.sendInputText('\x04');
+        break;
+      case 'ctrl+w':
+        await this.sendInputText('\x17');
+        break;
+      case 'ctrl+u':
+        await this.sendInputText('\x15');
+        break;
+      case 'alt+b':
+        await this.sendInputText('\x1bb'); // ESC + b
+        break;
+      case 'alt+f':
+        await this.sendInputText('\x1bf'); // ESC + f
+        break;
+      case 'cmd+k':
+        // On macOS, Cmd+K is often used to clear the terminal
+        await this.sendInputText('\x0b');
+        break;
+      case 'cmd+z':
+        await this.sendInputText('\x1a');
+        break;
+    }
+  }
+
   private handleCtrlAlphaToggle() {
     this.showCtrlAlpha = !this.showCtrlAlpha;
   }
@@ -1052,6 +1104,21 @@ export class SessionView extends LitElement {
           outline: 2px solid #00ff88 !important;
           outline-offset: -2px;
         }
+        /* Custom scrollbar styling for shortcuts */
+        .shortcuts-scrollbar::-webkit-scrollbar {
+          height: 6px;
+        }
+        .shortcuts-scrollbar::-webkit-scrollbar-track {
+          background: #1e1e1e;
+          border-radius: 3px;
+        }
+        .shortcuts-scrollbar::-webkit-scrollbar-thumb {
+          background: #569cd6;
+          border-radius: 3px;
+        }
+        .shortcuts-scrollbar::-webkit-scrollbar-thumb:hover {
+          background: #6ba3e0;
+        }
       </style>
       <div
         class="flex flex-col bg-dark-bg font-mono"
@@ -1251,28 +1318,127 @@ export class SessionView extends LitElement {
         ${this.isMobile && !this.showMobileInput
           ? html`
               <div class="flex-shrink-0 p-4" style="background: black;">
+                <!-- Horizontal scrollbar with shortcuts -->
+                <div
+                  class="overflow-x-auto mb-2 -mx-4 px-4 shortcuts-scrollbar"
+                  style="scrollbar-width: thin; scrollbar-color: #569cd6 #1e1e1e;"
+                >
+                  <div class="flex gap-2 pb-2" style="min-width: max-content;">
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('shift+tab')}
+                      title="Enable Claude Code file writes"
+                    >
+                      Shift+Tab
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+c')}
+                    >
+                      Ctrl+C
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+z')}
+                    >
+                      Ctrl+Z
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+a')}
+                    >
+                      Ctrl+A
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+e')}
+                    >
+                      Ctrl+E
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+k')}
+                    >
+                      Ctrl+K
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+l')}
+                    >
+                      Clear
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+r')}
+                    >
+                      Search
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+d')}
+                    >
+                      EOF
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+w')}
+                    >
+                      Del Word
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('ctrl+u')}
+                    >
+                      Del Line
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('alt+b')}
+                    >
+                      Word ←
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('alt+f')}
+                    >
+                      Word →
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('cmd+k')}
+                    >
+                      Cmd+K
+                    </button>
+                    <button
+                      class="font-mono px-3 py-2 text-xs transition-all cursor-pointer mobile-keyboard-btn whitespace-nowrap"
+                      @click=${() => this.handleShortcut('cmd+z')}
+                    >
+                      Undo
+                    </button>
+                  </div>
+                </div>
                 <!-- First row: Arrow keys -->
                 <div class="flex gap-2 mb-2">
                   <button
-                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer quick-start-btn"
+                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('arrow_up')}
                   >
                     <span class="text-xl">↑</span>
                   </button>
                   <button
-                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer quick-start-btn"
+                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('arrow_down')}
                   >
                     <span class="text-xl">↓</span>
                   </button>
                   <button
-                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer quick-start-btn"
+                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('arrow_left')}
                   >
                     <span class="text-xl">←</span>
                   </button>
                   <button
-                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer quick-start-btn"
+                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('arrow_right')}
                   >
                     <span class="text-xl">→</span>
@@ -1282,31 +1448,31 @@ export class SessionView extends LitElement {
                 <!-- Second row: Special keys -->
                 <div class="flex gap-2">
                   <button
-                    class="font-mono text-sm transition-all cursor-pointer w-16 quick-start-btn"
+                    class="font-mono text-sm transition-all cursor-pointer w-16 mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('escape')}
                   >
                     ESC
                   </button>
                   <button
-                    class="font-mono text-sm transition-all cursor-pointer w-16 quick-start-btn"
+                    class="font-mono text-sm transition-all cursor-pointer w-16 mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('\t')}
                   >
                     <span class="text-xl">⇥</span>
                   </button>
                   <button
-                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer quick-start-btn"
+                    class="flex-1 font-mono px-3 py-2 text-sm transition-all cursor-pointer mobile-keyboard-btn"
                     @click=${this.handleMobileInputToggle}
                   >
                     ABC123
                   </button>
                   <button
-                    class="font-mono text-sm transition-all cursor-pointer w-16 quick-start-btn"
+                    class="font-mono text-sm transition-all cursor-pointer w-16 mobile-keyboard-btn"
                     @click=${this.handleCtrlAlphaToggle}
                   >
                     CTRL
                   </button>
                   <button
-                    class="font-mono text-sm transition-all cursor-pointer w-16 quick-start-btn"
+                    class="font-mono text-sm transition-all cursor-pointer w-16 mobile-keyboard-btn"
                     @click=${() => this.handleSpecialKey('enter')}
                   >
                     <span class="text-xl">⏎</span>

--- a/web/src/client/styles.css
+++ b/web/src/client/styles.css
@@ -84,6 +84,33 @@
     @apply active:scale-95;
   }
 
+  /* Mobile keyboard buttons - specific class for keyboard shortcuts */
+  .mobile-keyboard-btn {
+    @apply bg-dark-bg-tertiary border border-dark-border rounded-lg px-4 py-3 h-12;
+    @apply text-dark-text-muted;
+    /* Slow transition for returning to normal state */
+    transition:
+      border-color 2s ease-out,
+      color 2s ease-out,
+      box-shadow 2s ease-out,
+      transform 0.2s ease-out;
+  }
+
+  /* Instant highlight when pressed */
+  .mobile-keyboard-btn:active {
+    @apply border-accent-green text-accent-green shadow-glow-green-sm;
+    @apply scale-95;
+    /* Override transition to make the active state instant */
+    transition: transform 0.1s ease-out;
+  }
+
+  /* Only apply hover styles on devices that support hover */
+  @media (hover: hover) {
+    .mobile-keyboard-btn:hover {
+      @apply border-accent-green text-accent-green shadow-glow-green-sm;
+    }
+  }
+
   .quick-start-btn.active {
     @apply bg-accent-green text-dark-bg border-accent-green shadow-glow-green-sm;
   }

--- a/web/src/server/pty/pty-manager.ts
+++ b/web/src/server/pty/pty-manager.ts
@@ -321,25 +321,29 @@ export class PtyManager extends EventEmitter {
         // Check for bell character (ASCII 7) - filter out OSC sequences
         if (data.includes('\x07')) {
           logger.debug(`Bell data in session ${session.id}: ${JSON.stringify(data)}`);
-          
+
           // Count total bells and OSC-terminated bells
           const totalBells = (data.match(/\x07/g) || []).length;
-          
+
           // Count OSC sequences terminated with bell: \x1b]...\x07
           const oscMatches = data.match(/\x1b]([^\x07\x1b]|\x1b[^]])*\x07/g) || [];
           const oscTerminatedBells = oscMatches.length;
-          
+
           // If there are more bells than OSC terminators, we have real bells
           const realBells = totalBells - oscTerminatedBells;
-          
+
           if (realBells > 0) {
-            logger.debug(`Real bell(s) detected in session ${session.id}: ${realBells} bells (${oscTerminatedBells} OSC-terminated)`);
+            logger.debug(
+              `Real bell(s) detected in session ${session.id}: ${realBells} bells (${oscTerminatedBells} OSC-terminated)`
+            );
             this.emit('bell', {
               sessionInfo: session.sessionInfo,
               timestamp: new Date(),
             });
           } else {
-            logger.debug(`Ignoring OSC sequence bells in session ${session.id}: ${oscTerminatedBells} OSC bells, ${realBells} real bells`);
+            logger.debug(
+              `Ignoring OSC sequence bells in session ${session.id}: ${oscTerminatedBells} OSC bells, ${realBells} real bells`
+            );
           }
         }
 


### PR DESCRIPTION
### TL;DR

Added keyboard shortcuts for mobile users to improve terminal interaction in Claude Code.

### What changed?

- Added a new horizontal scrollable shortcut bar for mobile users with common terminal commands:
  - Shift+Tab (enables Claude Code file writes)
  - Ctrl+C (interrupt/cancel)
  - Ctrl+Z (suspend process)
  - Ctrl+D (end of file/exit)
  - Ctrl+L (clear terminal)
- Implemented a `handleShortcut` method to process these keyboard shortcuts
- Created custom styling for the shortcut buttons and scrollbar
- Renamed CSS classes from `quick-start-btn` to `mobile-keyboard-btn` for better semantics
- Added specific mobile-friendly button styling with instant highlight on press

### How to test?

1. Open Claude Code on a mobile device
2. Verify the new horizontal shortcut bar appears above the arrow keys
3. Test each shortcut button to ensure it sends the correct terminal command:
   - Tap "Shift+Tab" to enable file writes
   - Tap "Ctrl+C" to interrupt a running process
   - Tap "Ctrl+Z" to suspend a process
   - Tap "Ctrl+D" to send EOF
   - Tap "Clear" to clear the terminal screen
4. Check that the scrollbar allows access to all shortcuts when screen width is limited

### Why make this change?

Mobile users previously had limited ability to send important terminal commands that require keyboard combinations. This change improves the mobile experience by providing direct access to common terminal shortcuts, making Claude Code more usable on touch devices without physical keyboards.